### PR TITLE
Stop workers on closing the server

### DIFF
--- a/LogicReinc.WebServer/HttpServer.cs
+++ b/LogicReinc.WebServer/HttpServer.cs
@@ -195,6 +195,9 @@ namespace LogicReinc.WebServer
         {
             Active = false;
 
+            if (ThreadPool != null)
+                ThreadPool.SetWorkerCount(0);
+
             if (_listener == null)
                 _listener.Close();
         }

--- a/LogicReinc.WebServer/WebServer.cs
+++ b/LogicReinc.WebServer/WebServer.cs
@@ -31,7 +31,7 @@ namespace LogicReinc.WebServer
         protected void Init()
         {
             Server.Routing.Clear();
-            
+
             RegisterFiles();
             RegisterRoutes();
             RegisterControllers();
@@ -51,6 +51,7 @@ namespace LogicReinc.WebServer
             {
                 Init();
                 Server.Start();
+                Active = true;
             }
         }
 


### PR DESCRIPTION
Kelvin,

On stopping the WebServer, not all Workers are stopped as it is now.
Which means the process is not stopped completely and the ip-port is kept in use.

I think setting the WorkerCount to 0 solves the problem, because all active workers are stopped.

Bert